### PR TITLE
Use unreleased websocket.io commit (Node 7 EventEmitter)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,23 +23,24 @@
   },
   "dependencies": {
     "ansi": "^0.3.0",
-    "bluebird": "^2.3.11",
+    "bluebird": "^3.4.7",
     "commander": "^2.5.1",
     "connect": "^3.3.3",
-    "connect-livereload": "^0.5.3",
-    "jsdom": "^8.0.0",
+    "connect-livereload": "^0.6.0",
+    "jsdom": "^9.9.1",
     "less": "^2.4.0",
     "livereload": "^0.3.6",
     "livereload-js": "^2.2.2",
     "marked": "git://github.com/f1lt3r/marked#master",
     "mime": "^1.2.11",
     "open": "0.0.5",
-    "openport": "0.0.3",
-    "send": "^0.10.1"
+    "openport": "0.0.4",
+    "send": "^0.14.1",
+    "websocket.io": "git://github.com/LearnBoost/websocket.io#5f0b3799f50944bc4d1eb58acdef61c38883d6cf"
   },
   "devDependencies": {
-    "connect-livereload": "^0.5.3",
-    "livereload": "^0.3.7",
+    "connect-livereload": "^0.6.0",
+    "livereload": "^0.6.0",
     "xo": "^0.17.0"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "http://github.com/f1lt3r/markserv.git"
+    "url": "http://github.com/f1lt3r/markserv-legacy.git"
   },
   "dependencies": {
     "ansi": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markserv",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "markserv serves Markdown files as GitHub style HTML and LiveReloads your files in the browser as you edit.",
   "keywords": [
     "markdown",


### PR DESCRIPTION
Websocket.io has a problem using the event emitter prototype as of changed to how Node 7 accesses events. It is not yet released, but you can follow updates here: https://github.com/LearnBoost/websocket.io/pull/57

I set the commit of the depedency in `package.json` to be the specific commit of websocket.io that is work (but remains unreleased).