### PR TITLE
Fix encoded URL will return 404

### DIFF
--- a/server.js
+++ b/server.js
@@ -347,7 +347,7 @@ const getPathFromUrl = url => {
 
 // http_request_handler: handles all the browser requests
 const httpRequestHandler = (req, res) => {
-  const originalUrl = getPathFromUrl(req.originalUrl);
+  const originalUrl = getPathFromUrl(decodeURIComponent(req.originalUrl));
 
   if (flags.verbose) {
     msg('request')


### PR DESCRIPTION
if a URL contains Chinese like `测试.md`, it will be encoded by Chrome to `%E6%B5%8B%E8%AF%95.md`.